### PR TITLE
feat(client): implement client portal views and custom hooks for tick…

### DIFF
--- a/frontend/src/hooks/use-client-dashboard.ts
+++ b/frontend/src/hooks/use-client-dashboard.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useAppSelector } from '@/store'
+import { selectUser } from '@/store/auth.slice'
+import { ticketService } from '@/services/ticket.service'
+import { packageService } from '@/services/package.service'
+import type { Ticket } from '@/types/ticket'
+import type { Package as Pkg } from '@/types/package'
+
+interface TripLike {
+  date?: string
+  trip_datetime?: string
+  route?: { origin?: { name?: string }; destination?: { name?: string } }
+}
+
+function ticketDate(t: Ticket): Date | null {
+  const trip = t.trip as TripLike | undefined
+  const raw = trip?.trip_datetime ?? trip?.date ?? t.created_at
+  if (!raw) return null
+  const d = new Date(raw as string)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+export function useClientDashboard() {
+  const user = useAppSelector(selectUser)
+  const clientId = user?.person?.id
+
+  const [tickets, setTickets] = useState<Ticket[]>([])
+  const [sent, setSent] = useState<Pkg[]>([])
+  const [received, setReceived] = useState<Pkg[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      if (!clientId) {
+        if (!cancelled) setLoading(false)
+        return
+      }
+      try {
+        const [t, s, r] = await Promise.all([
+          ticketService.getByClient(clientId),
+          packageService.getBySender(clientId),
+          packageService.getByRecipient(clientId),
+        ])
+        if (!cancelled) {
+          setTickets((t as Ticket[]) ?? [])
+          setSent((s as Pkg[]) ?? [])
+          setReceived((r as Pkg[]) ?? [])
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message || 'No se pudo cargar tu información')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [clientId])
+
+  const now = useMemo(() => new Date(), [])
+
+  const upcomingTickets = useMemo(() => {
+    return tickets
+      .filter((t) => {
+        const state = String(t.state ?? '')
+        if (state === 'cancelled' || state === 'expired') return false
+        const d = ticketDate(t)
+        return d ? d.getTime() >= now.getTime() : false
+      })
+      .sort((a, b) => (ticketDate(a)?.getTime() ?? 0) - (ticketDate(b)?.getTime() ?? 0))
+  }, [tickets, now])
+
+  const recentTickets = useMemo(() => {
+    return [...tickets]
+      .sort((a, b) => (ticketDate(b)?.getTime() ?? 0) - (ticketDate(a)?.getTime() ?? 0))
+      .slice(0, 4)
+  }, [tickets])
+
+  const pendingToReceive = useMemo(
+    () => received.filter((p) => String(p.status ?? '') !== 'delivered'),
+    [received],
+  )
+
+  const pendingToSend = useMemo(
+    () => sent.filter((p) => {
+      const s = String(p.status ?? '')
+      return s !== 'delivered'
+    }),
+    [sent],
+  )
+
+  const nextTrip = upcomingTickets[0]
+
+  return {
+    loading,
+    error,
+    tickets,
+    sent,
+    received,
+    upcomingTickets,
+    recentTickets,
+    pendingToReceive,
+    pendingToSend,
+    nextTrip,
+    stats: {
+      totalTickets: tickets.length,
+      upcomingCount: upcomingTickets.length,
+      sentCount: sent.length,
+      receivedCount: received.length,
+      pendingToReceiveCount: pendingToReceive.length,
+    },
+  }
+}

--- a/frontend/src/hooks/use-my-packages.ts
+++ b/frontend/src/hooks/use-my-packages.ts
@@ -1,0 +1,51 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useAppSelector } from '@/store'
+import { selectUser } from '@/store/auth.slice'
+import { packageService } from '@/services/package.service'
+import type { Package as Pkg } from '@/types/package'
+
+export type MyPackagesTab = 'sent' | 'received'
+
+export function useMyPackages() {
+  const user = useAppSelector(selectUser)
+  const clientId = user?.person?.id
+
+  const [tab, setTab] = useState<MyPackagesTab>('sent')
+  const [sent, setSent] = useState<Pkg[]>([])
+  const [received, setReceived] = useState<Pkg[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      if (!clientId) {
+        if (!cancelled) setLoading(false)
+        return
+      }
+      try {
+        const [s, r] = await Promise.all([
+          packageService.getBySender(clientId),
+          packageService.getByRecipient(clientId),
+        ])
+        if (!cancelled) {
+          setSent((s as Pkg[]) ?? [])
+          setReceived((r as Pkg[]) ?? [])
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message || 'No se pudieron cargar tus encomiendas')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [clientId])
+
+  const list = useMemo(() => (tab === 'sent' ? sent : received), [tab, sent, received])
+
+  return { tab, setTab, sent, received, list, loading, error }
+}

--- a/frontend/src/hooks/use-my-tickets.ts
+++ b/frontend/src/hooks/use-my-tickets.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState, useMemo } from 'react'
+import { useAppSelector } from '@/store'
+import { selectUser } from '@/store/auth.slice'
+import { ticketService } from '@/services/ticket.service'
+import type { Ticket, TicketState } from '@/types/ticket'
+
+export type TicketTab = 'all' | TicketState
+
+export function useMyTickets() {
+  const user = useAppSelector(selectUser)
+  const clientId = user?.person?.id
+
+  const [tab, setTab] = useState<TicketTab>('all')
+  const [tickets, setTickets] = useState<Ticket[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      if (!clientId) {
+        if (!cancelled) setLoading(false)
+        return
+      }
+      try {
+        const data = await ticketService.getByClient(clientId)
+        if (!cancelled) {
+          setTickets((data as Ticket[]) ?? [])
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message || 'No se pudieron cargar tus boletos')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [clientId])
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {
+      all: tickets.length,
+      pending: 0,
+      confirmed: 0,
+      paid: 0,
+      sold: 0,
+      cancelled: 0,
+      expired: 0
+    }
+    tickets.forEach((t) => {
+      if (c[t.state] !== undefined) {
+        c[t.state]++
+      } else {
+        c[t.state] = 1
+      }
+    })
+    return c
+  }, [tickets])
+
+  const list = useMemo(() => {
+    if (tab === 'all') return tickets
+    return tickets.filter((t) => t.state === tab)
+  }, [tickets, tab])
+
+  return { tab, setTab, list, counts, loading, error }
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -122,10 +122,10 @@ const CLIENT_NAV: NavGroup[] = [
     ],
   },
   {
-    title: 'Mis Viajes',
+    title: 'Mis Movimientos',
     items: [
-      { to: ROUTES.TRIPS, label: 'Viajes', icon: MapPin },
-      { to: ROUTES.PACKAGES, label: 'Encomiendas', icon: Package },
+      { to: ROUTES.MY_TICKETS, label: 'Mis Boletos', icon: Ticket },
+      { to: ROUTES.MY_PACKAGES, label: 'Mis Encomiendas', icon: Package },
     ],
   },
 ]

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -44,6 +44,9 @@ export const ROUTES = {
   CLIENTS: '/clients',
   clientEdit: (id: number | string) => `/clients/${id}/edit`,
 
+  MY_TICKETS: '/my-tickets',
+  MY_PACKAGES: '/my-packages',
+
   REPORTS: '/reports',
   REPORT_PACKAGES: '/reports/packages',
   SALES: '/sales',

--- a/frontend/src/pages/dashboards/ClientDashboard.tsx
+++ b/frontend/src/pages/dashboards/ClientDashboard.tsx
@@ -1,32 +1,308 @@
+import { Link } from 'react-router'
 import { useAuth } from '@/hooks/use-auth'
 import { useDocumentTitle } from '@/hooks/use-document-title'
-import { User, Ticket } from 'lucide-react'
+import { useClientDashboard } from '@/hooks/use-client-dashboard'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import EmptyState from '@/components/common/EmptyState'
+import {
+  Ticket as TicketIcon,
+  Package as PackageIcon,
+  Calendar,
+  Inbox,
+  Send,
+  AlertCircle,
+  ArrowRight,
+  MapPin,
+} from 'lucide-react'
+import { ROUTES } from '@/lib/routes'
+import { LOCALE } from '@/lib/locale-config'
+import {
+  getPackageStatusLabel,
+  getPackageStatusBg,
+  getPackageStatusText,
+} from '@/lib/package-status'
+import { cn } from '@/lib/utils'
+
+const STATE_LABEL: Record<string, string> = {
+  pending: 'Pendiente',
+  confirmed: 'Confirmado',
+  paid: 'Pagado',
+  sold: 'Vendido',
+  cancelled: 'Cancelado',
+  expired: 'Expirado',
+}
+
+const STATE_BADGE: Record<string, string> = {
+  pending: 'bg-amber-100 text-amber-800',
+  confirmed: 'bg-emerald-100 text-emerald-800',
+  paid: 'bg-emerald-100 text-emerald-800',
+  sold: 'bg-emerald-100 text-emerald-800',
+  cancelled: 'bg-red-100 text-red-800',
+  expired: 'bg-muted text-muted-foreground',
+}
+
+function formatDateTime(value?: string) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString(LOCALE, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function formatDate(value?: string) {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString(LOCALE, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function KpiCard({
+  label,
+  value,
+  icon: Icon,
+  hint,
+}: {
+  label: string
+  value: string | number
+  icon: typeof TicketIcon
+  hint?: string
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Icon className="h-5 w-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-2xl font-bold leading-tight text-foreground">{value}</div>
+            <div className="text-xs text-muted-foreground">{label}</div>
+            {hint && <div className="mt-0.5 text-xs text-muted-foreground/80">{hint}</div>}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
 
 export function Component() {
   useDocumentTitle('Panel de Cliente')
   const { user } = useAuth()
+  const {
+    loading,
+    error,
+    stats,
+    nextTrip,
+    recentTickets,
+    pendingToReceive,
+  } = useClientDashboard()
+
+  const nextTripData = nextTrip?.trip as
+    | { date?: string; trip_datetime?: string; route?: { origin?: { name?: string }; destination?: { name?: string } } }
+    | undefined
+  const nextTripDate = nextTripData?.trip_datetime ?? nextTripData?.date
+  const nextOrigin = nextTripData?.route?.origin?.name ?? '—'
+  const nextDestination = nextTripData?.route?.destination?.name ?? nextTrip?.destination ?? '—'
+
   return (
     <div className="w-full">
       <div className="border-b">
         <div className="w-full px-2 sm:px-4 lg:px-6 py-4">
           <div className="flex items-center gap-4">
-            <div className="flex items-center justify-center w-11 h-11 rounded-lg bg-primary/10 text-primary">
-              <User className="h-5 w-5" />
+            <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <TicketIcon className="h-5 w-5" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-foreground">Dashboard del Cliente</h1>
-              <p className="text-sm text-muted-foreground">Bienvenido, {user?.firstname} {user?.lastname}</p>
+              <h1 className="text-2xl font-bold text-foreground">Hola, {user?.firstname || 'cliente'}</h1>
+              <p className="text-sm text-muted-foreground">Aquí tienes un resumen de tus viajes y encomiendas</p>
             </div>
           </div>
         </div>
       </div>
-      <div className="w-full px-2 sm:px-4 lg:px-6 py-6">
-        <div className="bg-card border rounded-lg p-8 text-center">
-          <Ticket className="h-12 w-12 text-muted-foreground mx-auto mb-4" strokeWidth={1.5} />
-          <h2 className="text-base font-semibold text-foreground mb-1">Portal del cliente</h2>
-          <p className="text-sm text-muted-foreground">Aquí podrás ver tus boletos, paquetes y próximos viajes.</p>
-        </div>
+
+      <div className="w-full px-2 sm:px-4 lg:px-6 py-6 space-y-6">
+        {error && (
+          <Card role="alert" className="border-red-200">
+            <CardContent className="p-4 flex items-center gap-3">
+              <AlertCircle className="h-5 w-5 text-red-500" />
+              <p className="text-sm text-red-700">{error}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        <section aria-label="Resumen">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+            <KpiCard
+              label="Boletos comprados"
+              value={loading ? '—' : stats.totalTickets}
+              icon={TicketIcon}
+              hint={stats.upcomingCount > 0 ? `${stats.upcomingCount} próximos` : undefined}
+            />
+            <KpiCard
+              label="Próximo viaje"
+              value={loading ? '—' : nextTripDate ? formatDate(nextTripDate) : 'Sin viajes'}
+              icon={Calendar}
+            />
+            <KpiCard
+              label="Encomiendas enviadas"
+              value={loading ? '—' : stats.sentCount}
+              icon={Send}
+            />
+            <KpiCard
+              label="Encomiendas por recibir"
+              value={loading ? '—' : stats.pendingToReceiveCount}
+              icon={Inbox}
+              hint={stats.receivedCount > 0 ? `${stats.receivedCount} en total` : undefined}
+            />
+          </div>
+        </section>
+
+        {!loading && nextTrip && (
+          <section aria-labelledby="next-trip-heading">
+            <h2 id="next-trip-heading" className="mb-3 text-lg font-semibold text-foreground">Tu próximo viaje</h2>
+            <Card>
+              <CardContent className="p-5">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                      <MapPin className="h-6 w-6" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-base font-semibold text-foreground">
+                        {nextOrigin} → {nextDestination}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatDateTime(nextTripDate)} · Asiento #{nextTrip.seat?.seat_number ?? '—'}
+                      </p>
+                      <span
+                        className={cn(
+                          'mt-2 inline-block rounded-full px-2 py-0.5 text-xs font-medium',
+                          STATE_BADGE[String(nextTrip.state ?? '')] ?? 'bg-muted',
+                        )}
+                      >
+                        {STATE_LABEL[String(nextTrip.state ?? '')] ?? String(nextTrip.state)}
+                      </span>
+                    </div>
+                  </div>
+                  <Button asChild variant="outline" size="sm">
+                    <Link to={ROUTES.ticketDetail(nextTrip.id)} aria-label={`Ver detalle del boleto ${nextTrip.id}`}>
+                      Ver boleto
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+        )}
+
+        <section aria-labelledby="recent-tickets-heading">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 id="recent-tickets-heading" className="text-lg font-semibold text-foreground">Boletos recientes</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link to={ROUTES.MY_TICKETS}>
+                Ver todos
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+
+          {loading ? (
+            <div role="status" aria-live="polite" className="py-8 text-center text-sm text-muted-foreground">
+              Cargando...
+            </div>
+          ) : recentTickets.length === 0 ? (
+            <EmptyState title="Sin boletos" description="Aún no tienes boletos comprados." />
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {recentTickets.map((t) => {
+                const state = String(t.state ?? '')
+                const trip = t.trip as
+                  | { date?: string; trip_datetime?: string; route?: { origin?: { name?: string }; destination?: { name?: string } } }
+                  | undefined
+                const origin = trip?.route?.origin?.name ?? '—'
+                const destination = trip?.route?.destination?.name ?? t.destination ?? '—'
+                const tripDate = trip?.trip_datetime ?? trip?.date
+                return (
+                  <Link
+                    key={t.id}
+                    to={ROUTES.ticketDetail(t.id)}
+                    className="block rounded-lg border bg-card p-4 transition hover:border-primary/50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <div className="mb-2 flex items-start justify-between gap-2">
+                      <span className="text-sm font-semibold">Boleto #{t.id}</span>
+                      <span
+                        className={cn(
+                          'rounded-full px-2 py-0.5 text-xs font-medium',
+                          STATE_BADGE[state] ?? 'bg-muted',
+                        )}
+                      >
+                        {STATE_LABEL[state] ?? state}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium text-foreground">{origin} → {destination}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{formatDate(tripDate)}</p>
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        <section aria-labelledby="pending-packages-heading">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 id="pending-packages-heading" className="text-lg font-semibold text-foreground">Encomiendas por recibir</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link to={ROUTES.MY_PACKAGES}>
+                Ver todas
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+
+          {loading ? (
+            <div role="status" aria-live="polite" className="py-8 text-center text-sm text-muted-foreground">
+              Cargando...
+            </div>
+          ) : pendingToReceive.length === 0 ? (
+            <EmptyState
+              title="Sin encomiendas pendientes"
+              description="No tienes encomiendas por recibir en este momento."
+            />
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {pendingToReceive.slice(0, 6).map((p) => {
+                const status = String(p.status ?? '')
+                return (
+                  <Link
+                    key={p.id}
+                    to={ROUTES.packageDetail(p.id)}
+                    className="block rounded-lg border bg-card p-4 transition hover:border-primary/50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <div className="mb-2 flex items-start justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <PackageIcon className="h-4 w-4 text-primary" />
+                        <span className="text-sm font-semibold">{p.tracking_code ?? `#${p.id}`}</span>
+                      </div>
+                      <span
+                        className={cn(
+                          'rounded-full px-2 py-0.5 text-xs font-medium',
+                          getPackageStatusBg(status),
+                          getPackageStatusText(status),
+                        )}
+                      >
+                        {getPackageStatusLabel(status)}
+                      </span>
+                    </div>
+                    <p className="text-sm text-foreground">De {p.sender_name ?? '—'}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {p.origin_name ?? '—'} → {p.destination_name ?? '—'}
+                    </p>
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+        </section>
       </div>
     </div>
   )
 }
+
+export default Component

--- a/frontend/src/pages/my/MyPackagesPage.tsx
+++ b/frontend/src/pages/my/MyPackagesPage.tsx
@@ -1,0 +1,138 @@
+import { Link } from 'react-router'
+import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useMyPackages } from '@/hooks/use-my-packages'
+import EmptyState from '@/components/common/EmptyState'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Package as PackageIcon, AlertCircle, Send, Inbox, ArrowRight, CalendarDays, User } from 'lucide-react'
+import { ROUTES } from '@/lib/routes'
+import { LOCALE } from '@/lib/locale-config'
+import { getPackageStatusLabel, getPackageStatusBg, getPackageStatusText } from '@/lib/package-status'
+import { cn } from '@/lib/utils'
+
+function formatDate(value?: string) {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString(LOCALE, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export function Component() {
+  useDocumentTitle('Mis Encomiendas')
+  const { tab, setTab, sent, received, list, loading, error } = useMyPackages()
+
+  return (
+    <div className="w-full space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Mis Encomiendas</h1>
+        <p className="text-sm text-muted-foreground">Encomiendas que enviaste o recibiste</p>
+      </div>
+
+      <div role="tablist" aria-label="Filtrar encomiendas" className="inline-flex rounded-lg border bg-card p-1 gap-1">
+        <Button
+          type="button"
+          variant={tab === 'sent' ? 'default' : 'ghost'}
+          size="sm"
+          role="tab"
+          aria-selected={tab === 'sent'}
+          onClick={() => setTab('sent')}
+          className="min-h-[44px]"
+        >
+          <Send className="h-4 w-4 mr-2" />
+          Enviadas ({sent.length})
+        </Button>
+        <Button
+          type="button"
+          variant={tab === 'received' ? 'default' : 'ghost'}
+          size="sm"
+          role="tab"
+          aria-selected={tab === 'received'}
+          onClick={() => setTab('received')}
+          className="min-h-[44px]"
+        >
+          <Inbox className="h-4 w-4 mr-2" />
+          Recibidas ({received.length})
+        </Button>
+      </div>
+
+      {error && (
+        <Card role="alert" className="border-red-200">
+          <CardContent className="p-4 flex items-center gap-3">
+            <AlertCircle className="h-5 w-5 text-red-500" />
+            <p className="text-sm text-red-700">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {loading ? (
+        <div role="status" aria-live="polite" className="text-center py-12 text-muted-foreground">
+          Cargando...
+        </div>
+      ) : list.length === 0 ? (
+        <EmptyState
+          title={tab === 'sent' ? 'Sin encomiendas enviadas' : 'Sin encomiendas recibidas'}
+          description={tab === 'sent' ? 'No has enviado encomiendas aún.' : 'No tienes encomiendas a tu nombre.'}
+        />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {list.map((p) => {
+            const status = String(p.status ?? '')
+            const counterpartLabel = tab === 'sent' ? 'Para' : 'De'
+            const counterpartName = tab === 'sent' ? p.recipient_name : p.sender_name
+            return (
+              <Link
+                key={p.id}
+                to={ROUTES.packageDetail(p.id)}
+                className="group block overflow-hidden rounded-xl border border-border bg-card shadow-sm hover:border-primary/50 hover:shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                {/* Header */}
+                <div className="border-b border-border bg-muted/20 px-4 py-3 flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <PackageIcon className="h-4 w-4 text-primary" />
+                    <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">{p.tracking_code ?? `#${p.id}`}</span>
+                  </div>
+                  <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold', getPackageStatusBg(status), getPackageStatusText(status))}>
+                    {getPackageStatusLabel(status)}
+                  </span>
+                </div>
+
+                {/* Route */}
+                <div className="px-4 py-4">
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
+                    <div className="min-w-0">
+                      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground truncate">Origen</p>
+                      <h3 className="truncate text-base font-extrabold leading-tight text-foreground" title={p.origin_name ?? '—'}>{p.origin_name ?? '—'}</h3>
+                    </div>
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-muted/30 text-muted-foreground flex-shrink-0 group-hover:bg-primary group-hover:text-primary-foreground group-hover:border-primary transition-colors">
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </div>
+                    <div className="min-w-0 text-right">
+                      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground truncate">Destino</p>
+                      <h3 className="truncate text-base font-extrabold leading-tight text-foreground" title={p.destination_name ?? '—'}>{p.destination_name ?? '—'}</h3>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Details Footer */}
+                <div className="grid grid-cols-2 gap-3 border-t border-border px-4 py-3 bg-muted/5">
+                  <div className="flex flex-col min-w-0">
+                    <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider leading-tight flex items-center gap-1 mb-0.5">
+                      <User className="h-3 w-3" /> {counterpartLabel}
+                    </p>
+                    <p className="text-sm font-bold text-foreground truncate" title={counterpartName ?? '—'}>{counterpartName ?? '—'}</p>
+                  </div>
+                  <div className="flex flex-col min-w-0 text-right items-end">
+                    <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider leading-tight flex items-center gap-1 mb-0.5">
+                      <CalendarDays className="h-3 w-3" /> Registrada
+                    </p>
+                    <p className="text-sm font-bold text-foreground truncate">{formatDate(p.created_at)}</p>
+                  </div>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Component

--- a/frontend/src/pages/my/MyTicketsPage.tsx
+++ b/frontend/src/pages/my/MyTicketsPage.tsx
@@ -1,0 +1,159 @@
+import { Link } from 'react-router'
+import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useMyTickets } from '@/hooks/use-my-tickets'
+import EmptyState from '@/components/common/EmptyState'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Ticket as TicketIcon, AlertCircle, ArrowRight, CalendarDays, Banknote, Armchair } from 'lucide-react'
+import { ROUTES } from '@/lib/routes'
+import { LOCALE } from '@/lib/locale-config'
+
+const STATE_LABEL: Record<string, string> = {
+  pending: 'Pendiente',
+  confirmed: 'Confirmado',
+  paid: 'Pagado',
+  sold: 'Vendido',
+  cancelled: 'Cancelado',
+  expired: 'Expirado',
+}
+
+const STATE_BADGE: Record<string, string> = {
+  pending: 'bg-amber-100 text-amber-800',
+  confirmed: 'bg-emerald-100 text-emerald-800',
+  paid: 'bg-emerald-100 text-emerald-800',
+  sold: 'bg-emerald-100 text-emerald-800',
+  cancelled: 'bg-red-100 text-red-800',
+  expired: 'bg-muted text-muted-foreground',
+}
+
+function formatDate(value?: string) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString(LOCALE, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function formatMoney(amount?: number) {
+  if (typeof amount !== 'number') return '—'
+  return `Bs ${amount.toFixed(2)}`
+}
+
+export function Component() {
+  useDocumentTitle('Mis Boletos')
+  const { tab, setTab, list, counts, loading, error } = useMyTickets()
+
+  return (
+    <div className="w-full space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Mis Boletos</h1>
+        <p className="text-sm text-muted-foreground">Boletos que has comprado</p>
+      </div>
+
+      <div className="w-full overflow-x-auto pb-2 hide-scrollbar">
+        <div role="tablist" aria-label="Filtrar boletos" className="inline-flex rounded-lg border bg-card p-1 gap-1">
+          {['all', 'pending', 'confirmed', 'paid', 'sold', 'cancelled', 'expired'].map((stateKey) => (
+            <Button
+              key={stateKey}
+              type="button"
+              variant={tab === stateKey ? 'default' : 'ghost'}
+              size="sm"
+              role="tab"
+              aria-selected={tab === stateKey}
+              onClick={() => setTab(stateKey as any)}
+              className="min-h-[44px] whitespace-nowrap"
+            >
+              {stateKey === 'all' ? 'Todos' : STATE_LABEL[stateKey]} ({counts[stateKey] ?? 0})
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <Card role="alert" className="border-red-200">
+          <CardContent className="p-4 flex items-center gap-3">
+            <AlertCircle className="h-5 w-5 text-red-500" />
+            <p className="text-sm text-red-700">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {loading ? (
+        <div role="status" aria-live="polite" className="text-center py-12 text-muted-foreground">
+          Cargando...
+        </div>
+      ) : list.length === 0 ? (
+        <EmptyState
+          title={tab === 'all' ? 'Sin boletos' : `Sin boletos en estado ${STATE_LABEL[tab]}`}
+          description={tab === 'all' ? 'Aún no tienes boletos comprados.' : `No tienes boletos con estado ${STATE_LABEL[tab].toLowerCase()}.`}
+        />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {list.map((t) => {
+            const state = String(t.state ?? '')
+            const trip = t.trip as { date?: string; route?: { origin?: { name?: string }; destination?: { name?: string } } } | undefined
+            const origin = trip?.route?.origin?.name ?? '—'
+            const destination = trip?.route?.destination?.name ?? t.destination ?? '—'
+            const seatNumber = t.seat?.seat_number ?? '—'
+            return (
+              <Link
+                key={t.id}
+                to={ROUTES.ticketDetail(t.id)}
+                className="group block overflow-hidden rounded-xl border border-border bg-card shadow-sm hover:border-primary/50 hover:shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                {/* Header */}
+                <div className="border-b border-border bg-muted/20 px-4 py-3 flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <TicketIcon className="h-4 w-4 text-primary" />
+                    <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">Boleto #{t.id}</span>
+                  </div>
+                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold ${STATE_BADGE[state] ?? 'bg-muted text-muted-foreground'}`}>
+                    {STATE_LABEL[state] ?? state}
+                  </span>
+                </div>
+
+                {/* Route */}
+                <div className="px-4 py-4">
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
+                    <div className="min-w-0">
+                      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground truncate">Origen</p>
+                      <h3 className="truncate text-base font-extrabold leading-tight text-foreground" title={origin}>{origin}</h3>
+                    </div>
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-muted/30 text-muted-foreground flex-shrink-0 group-hover:bg-primary group-hover:text-primary-foreground group-hover:border-primary transition-colors">
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </div>
+                    <div className="min-w-0 text-right">
+                      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground truncate">Destino</p>
+                      <h3 className="truncate text-base font-extrabold leading-tight text-foreground" title={destination}>{destination}</h3>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Details Footer */}
+                <div className="grid grid-cols-3 gap-3 border-t border-border px-4 py-3 bg-muted/5">
+                  <div className="flex flex-col min-w-0">
+                    <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider leading-tight flex items-center gap-1 mb-0.5">
+                      <CalendarDays className="h-3 w-3" /> Fecha
+                    </p>
+                    <p className="text-sm font-bold text-foreground truncate" title={formatDate(trip?.date)}>{formatDate(trip?.date)}</p>
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider leading-tight flex items-center gap-1 mb-0.5">
+                      <Armchair className="h-3 w-3" /> Asiento
+                    </p>
+                    <p className="text-sm font-bold text-foreground truncate">#{seatNumber}</p>
+                  </div>
+                  <div className="flex flex-col min-w-0 text-right items-end">
+                    <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider leading-tight flex items-center gap-1 mb-0.5">
+                      <Banknote className="h-3 w-3" /> Precio
+                    </p>
+                    <p className="text-sm font-bold text-foreground truncate">{formatMoney(t.price)}</p>
+                  </div>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Component

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -75,24 +75,37 @@ export const router = createBrowserRouter([
             ],
           },
 
-          // Trips
-          { path: '/trips', lazy: () => import('@/pages/trips/TripsIndexPage') },
-{ path: '/trips/:id', lazy: () => import('@/pages/trips/TripDetailPage') },
-          { path: '/trips/:id/edit', lazy: () => import('@/pages/trips/TripEditPage') },
+          // Operaciones — solo staff (no clientes)
+          {
+            element: <RoleGuardOutlet roles={['admin', 'secretary', 'driver', 'assistant']} />,
+            children: [
+              { path: '/trips', lazy: () => import('@/pages/trips/TripsIndexPage') },
+              { path: '/trips/:id', lazy: () => import('@/pages/trips/TripDetailPage') },
+              { path: '/trips/:id/edit', lazy: () => import('@/pages/trips/TripEditPage') },
 
-          // Packages
-          { path: '/packages', lazy: () => import('@/pages/packages/PackagesIndexPage') },
-          { path: '/packages/pending-collections', lazy: () => import('@/pages/packages/PendingCollectionsPage') },
-          { path: '/packages/new', lazy: () => import('@/pages/packages/PackageNewPage') },
+              { path: '/packages', lazy: () => import('@/pages/packages/PackagesIndexPage') },
+              { path: '/packages/pending-collections', lazy: () => import('@/pages/packages/PendingCollectionsPage') },
+              { path: '/packages/new', lazy: () => import('@/pages/packages/PackageNewPage') },
+
+              { path: '/tickets', lazy: () => import('@/pages/tickets/TicketsIndexPage') },
+              { path: '/tickets/confirmation', lazy: () => import('@/pages/tickets/TicketConfirmationPage') },
+
+              { path: '/clients', lazy: () => import('@/pages/clients/ClientsIndexPage') },
+            ],
+          },
+
+          // Detalle de boleto/encomienda — accesible a todos (backend valida pertenencia)
+          { path: '/tickets/:id', lazy: () => import('@/pages/tickets/TicketDetailPage') },
           { path: '/packages/:id', lazy: () => import('@/pages/packages/PackageDetailPage') },
 
-          // Tickets
-          { path: '/tickets/confirmation', lazy: () => import('@/pages/tickets/TicketConfirmationPage') },
-          { path: '/tickets/:id', lazy: () => import('@/pages/tickets/TicketDetailPage') },
-
-          // Clients & Bookings
-          { path: '/clients', lazy: () => import('@/pages/clients/ClientsIndexPage') },
-          { path: '/tickets', lazy: () => import('@/pages/tickets/TicketsIndexPage') },
+          // Vistas del cliente — solo rol client
+          {
+            element: <RoleGuardOutlet roles={['client']} />,
+            children: [
+              { path: '/my-tickets', lazy: () => import('@/pages/my/MyTicketsPage') },
+              { path: '/my-packages', lazy: () => import('@/pages/my/MyPackagesPage') },
+            ],
+          },
         ],
       },
     ],

--- a/frontend/src/services/package.service.ts
+++ b/frontend/src/services/package.service.ts
@@ -62,6 +62,14 @@ export const packageService = {
         return apiFetch(`${BASE_PATH}/by-trip/${tripId}`)
     },
 
+    getBySender(clientId: number) {
+        return apiFetch(`${BASE_PATH}/by-sender/${clientId}`)
+    },
+
+    getByRecipient(clientId: number) {
+        return apiFetch(`${BASE_PATH}/by-recipient/${clientId}`)
+    },
+
     search(term: string) {
         return apiFetch(`${BASE_PATH}/search`, { params: { q: term } })
     },

--- a/frontend/src/services/ticket.service.ts
+++ b/frontend/src/services/ticket.service.ts
@@ -27,6 +27,10 @@ export const ticketService = {
         return apiFetch(`${RESOURCE_URL}/trip/${tripId}`)
     },
 
+    getByClient(clientId: number) {
+        return apiFetch(`${RESOURCE_URL}/client/${clientId}`)
+    },
+
     search(term: string, limit: number = 20) {
         return apiFetch(`${RESOURCE_URL}/search`, { params: { term, limit } })
     },


### PR DESCRIPTION
…ets/packages

- Add 'MyTicketsPage' and 'MyPackagesPage' under '/my-tickets' and '/my-packages' routes
- Encapsulate data fetching and filtering in custom hooks 'useClientDashboard', 'useMyTickets', and 'useMyPackages'
- Re-architect routing structure in router/index.tsx to secure operational views with RoleGuardOutlet for staff and client views for client roles
- Move ticket/package detail views to be accessible to all roles with backend-validated ownership
- Update client navigation sidebar items to 'Mis Boletos' and 'Mis Encomiendas' under a unified 'Mis Movimientos' category
- Extend ticket and package services with client-specific fetch endpoints